### PR TITLE
Update Eventmachine to 1.0.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
     em-websocket (0.5.0)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.5.3)
-    eventmachine (1.0.3)
+    eventmachine (1.0.7)
     execjs (1.4.0)
       multi_json (~> 1.0)
     exifr (1.1.3)


### PR DESCRIPTION
For compatibility with newer version of MRI
